### PR TITLE
Remove font-plemol-jp-nfj from instruction of homebrew

### DIFF
--- a/doc/install_via_homebrew.md
+++ b/doc/install_via_homebrew.md
@@ -4,6 +4,5 @@
 brew tap homebrew/cask-fonts
 brew install font-plemol-jp
 brew install font-plemol-jp-nf
-brew install font-plemol-jp-nfj
 brew install font-plemol-jp-hs
 ```


### PR DESCRIPTION
v1.6.0でPlemolJP_NFJは同梱されなくなり、Homebrew側からも消えていてインストールできなくなっているため、Homebrewに関する手順を更新しました。