### PR TITLE
Update install_via_homebrew.md

### DIFF
--- a/doc/install_via_homebrew.md
+++ b/doc/install_via_homebrew.md
@@ -1,8 +1,7 @@
 ### Homebrew を用いたインストールコマンド
 
 ```
-brew tap homebrew/cask-fonts
-brew install font-plemol-jp
-brew install font-plemol-jp-nf
-brew install font-plemol-jp-hs
+brew install --cask font-plemol-jp
+brew install --cask font-plemol-jp-nf
+brew install --cask font-plemol-jp-hs
 ```


### PR DESCRIPTION
Homebrewを用いたインストール方法について、`brew tap homebrew/cask-fonts`の部分をコピペで動かした際に以下のようならエラーが出たので、最近のHomebrewでエラーが出ないように更新しました。
```
Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

### 変更点
- `brew tap homebrew/cask-fonts`は不要になったので削除
- `brew install`コマンドに`—cask`オプションを追加